### PR TITLE
Bumps version to 1.0.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False


### PR DESCRIPTION
The Terraform registry pins the docs to the tag, so need to release a new tag to get it to update.